### PR TITLE
Make HTTParty options configurable

### DIFF
--- a/lib/bamboozled.rb
+++ b/lib/bamboozled.rb
@@ -16,8 +16,8 @@ require "bamboozled/api/meta"
 module Bamboozled
   class << self
     # Creates a standard client that will raise all errors it encounters
-    def client(subdomain: nil, api_key: nil)
-      Bamboozled::Base.new(subdomain: subdomain, api_key: api_key)
+    def client(subdomain: nil, api_key: nil, httparty_options: {})
+      Bamboozled::Base.new(subdomain: subdomain, api_key: api_key, httparty_options: httparty_options)
     end
   end
 end

--- a/lib/bamboozled/api/base.rb
+++ b/lib/bamboozled/api/base.rb
@@ -6,8 +6,10 @@ module Bamboozled
     class Base
       attr_reader :subdomain, :api_key
 
-      def initialize(subdomain, api_key)
-        @subdomain, @api_key = subdomain, api_key
+      def initialize(subdomain, api_key, httparty_options = {})
+        @subdomain = subdomain
+        @api_key = api_key
+        @httparty_options = httparty_options || {}
       end
 
       protected
@@ -18,7 +20,7 @@ module Bamboozled
             method:  method
           }
 
-          httparty_options = {
+          httparty_options = @httparty_options.merge({
             query:  options[:query],
             body:   options[:body],
             format: :plain,
@@ -27,7 +29,7 @@ module Bamboozled
               "Accept"       => "application/json",
               "User-Agent"   => "Bamboozled/#{Bamboozled::VERSION}"
             }.update(options[:headers] || {})
-          }
+          })
 
           response = HTTParty.send(method, "#{path_prefix}#{path}", httparty_options)
           params[:response] = response.inspect.to_s

--- a/lib/bamboozled/base.rb
+++ b/lib/bamboozled/base.rb
@@ -2,28 +2,30 @@ module Bamboozled
   class Base
     attr_reader :request
 
-    def initialize(subdomain: nil, api_key: nil)
-      @subdomain, @api_key = subdomain, api_key
+    def initialize(subdomain: nil, api_key: nil, httparty_options: {})
+      @subdomain, @api_key = subdomain
+      @api_key = api_key
+      @httparty_options = httparty_options
     end
 
     def employee
-      @employee ||= Bamboozled::API::Employee.new(@subdomain, @api_key)
+      @employee ||= Bamboozled::API::Employee.new(@subdomain, @api_key, @httparty_options)
     end
 
     def report
-      @report ||= Bamboozled::API::Report.new(@subdomain, @api_key)
+      @report ||= Bamboozled::API::Report.new(@subdomain, @api_key, @httparty_options)
     end
 
     def meta
-      @meta ||= Bamboozled::API::Meta.new(@subdomain, @api_key)
+      @meta ||= Bamboozled::API::Meta.new(@subdomain, @api_key, @httparty_options)
     end
 
     def time_off
-      @time_off ||= Bamboozled::API::TimeOff.new(@subdomain, @api_key)
+      @time_off ||= Bamboozled::API::TimeOff.new(@subdomain, @api_key, @httparty_options)
     end
 
     def time_tracking
-      @time_tracking ||= Bamboozled::API::TimeTracking.new(@subdomain, @api_key)
+      @time_tracking ||= Bamboozled::API::TimeTracking.new(@subdomain, @api_key, @httparty_options)
     end
   end
 end

--- a/spec/lib/bamboozled/api/base_spec.rb
+++ b/spec/lib/bamboozled/api/base_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe "Bamboozled::API::Base" do
+  it "takes HTTParty options as a constructor parameter" do
+    expect { Bamboozled::API::Base.new("x", "x", { log_format: :curl }) }.not_to raise_error
+  end
+
+  it "uses passed HTTParty options" do
+    response = double("response", code: 200, body: "{}", to_str: "{}")
+
+    expect(HTTParty).to receive(:get).
+      with("https://api.bamboohr.com/api/gateway.php/x/v1/test", hash_including(log_format: :curl)).
+      and_return(response)
+
+    base = Bamboozled::API::Base.new("x", "x", { log_format: :curl })
+    base.send(:request, :get, "test")
+  end
+end

--- a/spec/lib/bamboozled/base_spec.rb
+++ b/spec/lib/bamboozled/base_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+RSpec.describe "Bamboozled::Base" do
+  let(:base) { Bamboozled::Base.new(subdomain: "x", api_key: "x", httparty_options: {log_format: :curl}) }
+
+  it "passes HTTParty options to Bamboozled::API::Employee constructor" do
+    expect(Bamboozled::API::Employee).to receive(:new).with("x", "x", { log_format: :curl })
+    base.employee
+  end
+  it "passes HTTParty options to Bamboozled::API::Report constructor" do
+    expect(Bamboozled::API::Report).to receive(:new).with("x", "x", { log_format: :curl })
+    base.report
+  end
+  it "passes HTTParty options to Bamboozled::API::Meta constructor" do
+    expect(Bamboozled::API::Meta).to receive(:new).with("x", "x", { log_format: :curl })
+    base.meta
+  end
+  it "passes HTTParty options to Bamboozled::API::TimeOff constructor" do
+    expect(Bamboozled::API::TimeOff).to receive(:new).with("x", "x", { log_format: :curl })
+    base.time_off
+  end
+  it "passes HTTParty options to Bamboozled::API::TimeTracking constructor" do
+    expect(Bamboozled::API::TimeTracking).to receive(:new).with("x", "x", { log_format: :curl })
+    base.time_tracking
+  end
+end

--- a/spec/lib/bamboozled_spec.rb
+++ b/spec/lib/bamboozled_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+RSpec.describe "Bamboozled" do
+  it "takes HTTParty options as a parameter" do
+    expect(Bamboozled::Base).to receive(:new).with(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
+    Bamboozled.client(subdomain: "x", api_key: "x", httparty_options: { log_format: :curl })
+  end
+
+  it "throws no errors if no HTTParty options were provided (they are optional)" do
+    expect { Bamboozled.client(subdomain: "x", api_key: "x") }.not_to raise_error
+  end
+
+  it "passes HTTParty params to HTTParty" do
+    logger = double("logger")
+    allow(Time).to receive_message_chain(:now, :strftime).and_return("Time.now")
+    expect(logger).to receive(:info).with('[HTTParty] [Time.now] 200 "GET https://api.bamboohr.com/api/gateway.php/x/v1/employees/1234?fields=" - ')
+
+    client = Bamboozled.client(subdomain: "x", api_key: "x", httparty_options: { log_format: :apache, logger: logger })
+    response = File.new("spec/fixtures/one_employee.json")
+    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+    employee = client.employee.find(1234)
+  end
+
+  it "works without HTTParty options provided" do
+    client = Bamboozled.client(subdomain: "x", api_key: "x")
+    response = File.new("spec/fixtures/one_employee.json")
+    stub_request(:any, /.*api\.bamboohr\.com.*/).to_return(response)
+
+    employee = client.employee.find(1234)
+    expect(employee["firstName"]).to eq "John"
+  end
+end


### PR DESCRIPTION
This PR allows to pass options to HTTParty gem that is used to make HTTP calls to BambooHR API. 